### PR TITLE
Formatting functions

### DIFF
--- a/frontend/src/pages/InstallationsPage/index.jsx
+++ b/frontend/src/pages/InstallationsPage/index.jsx
@@ -85,7 +85,7 @@ export default function InstallationsPage(params) {
         <ErrorSplash
           title={error.context}
           message={error.error}
-          backaction={()=>getInstallations()}
+          backaction={() => getInstallations()}
           backtext={t('INSTALLATIONS.RELOAD')}
         />
       ) : (

--- a/frontend/src/services/format.js
+++ b/frontend/src/services/format.js
@@ -3,11 +3,15 @@ import i18n from '../i18n/i18n'
 function euros(amount) {
   const asFloat = parseFloat(amount)
   if (isNaN(asFloat)) return '-- €'
-  const localized = asFloat.toLocaleString('es', {
+  const language = i18n.language
+  const localized = asFloat.toLocaleString(language, {
+    style: 'currency',
+    currency: 'EUR',
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
+    useGrouping: true,
   })
-  return `${localized} €`
+  return `${localized}`
 }
 
 function date(adate) {

--- a/frontend/src/services/format.js
+++ b/frontend/src/services/format.js
@@ -1,19 +1,23 @@
 import i18n from '../i18n/i18n'
 
 function euros(amount) {
-    const numberAmount = parseFloat(amount)
-    if (isNaN(numberAmount)) return '-- €'
-    return `${numberAmount.toLocaleString('es', { maximumFractionDigits: 2, minimumFractionDigits: 2 })} €`
+  const asFloat = parseFloat(amount)
+  if (isNaN(asFloat)) return '-- €'
+  const localized = asFloat.toLocaleString('es', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  })
+  return `${localized} €`
 }
 
 function date(adate) {
-    const language = i18n.language
-    const formatter = new Intl.DateTimeFormat(language)
-    if (!adate) {
-        return formatter.format(new Date('1111/11/11')).replace(/1/g,'-') 
-    }
-    return formatter.format(new Date(adate)) 
+  const language = i18n.language
+  const formatter = new Intl.DateTimeFormat(language)
+  if (!adate) {
+    return formatter.format(new Date('1111-11-11')).replace(/[0-9]/g, '-')
+  }
+  return formatter.format(new Date(adate))
 }
 
 export { euros, date }
-export default {euros, date}
+export default { euros, date }

--- a/frontend/src/services/format.js
+++ b/frontend/src/services/format.js
@@ -1,0 +1,19 @@
+import i18n from '../i18n/i18n'
+
+function euros(amount) {
+    const numberAmount = parseFloat(amount)
+    if (isNaN(numberAmount)) return '-- €'
+    return `${numberAmount.toLocaleString('es', { maximumFractionDigits: 2, minimumFractionDigits: 2 })} €`
+}
+
+function date(adate) {
+    const language = i18n.language
+    const formatter = new Intl.DateTimeFormat(language)
+    if (!adate) {
+        return formatter.format(new Date('1111/11/11')).replace(/1/g,'-') 
+    }
+    return formatter.format(new Date(adate)) 
+}
+
+export { euros, date }
+export default {euros, date}

--- a/frontend/src/services/format.js
+++ b/frontend/src/services/format.js
@@ -23,5 +23,10 @@ function date(adate) {
   return formatter.format(new Date(adate))
 }
 
-export { euros, date }
-export default { euros, date }
+function enumeration(value, options) {
+  if (value===undefined) return '-'
+  return options[value] ?? '???'
+}
+
+export { euros, date, enumeration }
+export default { euros, date, enumeration }

--- a/frontend/src/services/format.test.js
+++ b/frontend/src/services/format.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, expect, test, it } from 'vitest'
-import { euros, date } from './format'
+import { euros, date, enumeration } from './format'
 import i18n from '../i18n/i18n'
 
 
@@ -78,5 +78,26 @@ describe('dates formatting', () => {
   it('undefined euskara', () => {
     i18n.changeLanguage('eu')
     expect(date(undefined)).toBe('----/--/--')
+  })
+})
+
+describe('enum formatting', () => {
+  var previousLanguage
+  var enum_options={
+    option1: "Option 1",
+    option2: "Option 2",
+  }
+
+  it('Option 1', () => {
+    expect(enumeration('option1', enum_options)).toBe('Option 1')
+  })
+  it('Option 2', () => {
+    expect(enumeration('option2', enum_options)).toBe('Option 2')
+  })
+  it('Non existing option', () => {
+    expect(enumeration('nooption', enum_options)).toBe('???')
+  })
+  it('Undefined value', () => {
+    expect(enumeration(undefined, enum_options)).toBe('-')
   })
 })

--- a/frontend/src/services/format.test.js
+++ b/frontend/src/services/format.test.js
@@ -4,29 +4,50 @@ import i18n from '../i18n/i18n'
 
 
 describe('euros formatting', () => {
+  var previousLanguage
+  beforeEach(()=>{
+    previousLanguage = i18n.language
+    i18n.changeLanguage('es')
+  })
+  afterEach(()=>{
+    i18n.changeLanguage(previousLanguage)
+  })
   it('amount with no decimals', () => {
-    expect(euros(2)).toBe('2,00 €')
+    expect(euros(2)).toBe('2,00 €')
   })
   it('amount with two decimals', () => {
-    expect(euros(2.15)).toBe('2,15 €')
+    expect(euros(2.15)).toBe('2,15 €')
   })
   it('amount with rounding up', () => {
-    expect(euros(2.159)).toBe('2,16 €')
+    expect(euros(2.159)).toBe('2,16 €')
   })
   it('amount with rounding down', () => {
-    expect(euros(2.151)).toBe('2,15 €')
+    expect(euros(2.151)).toBe('2,15 €')
   })
   it('amount with rounding middle', () => {
-    expect(euros(2.155)).toBe('2,16 €')
+    expect(euros(2.155)).toBe('2,16 €')
   })
   it('amount with negative', () => {
-    expect(euros(-2)).toBe('-2,00 €')
+    expect(euros(-2)).toBe('-2,00 €')
   })
   it('amount with string number', () => {
-    expect(euros('-2')).toBe('-2,00 €')
+    expect(euros('-2')).toBe('-2,00 €')
   })
   it('amount with undefined', () => {
     expect(euros(undefined)).toBe('-- €')
+  })
+  it('amount over thousands puts point', () => {
+    i18n.changeLanguage('es')
+
+    expect(euros(2345)).toBe('2.345,00 €')
+  })
+  it('basque locale', () => {
+    i18n.changeLanguage('eu')
+    expect(euros(2345)).toBe('2.345,00 €')
+  })
+  it('english locale', () => {
+    i18n.changeLanguage('en')
+    expect(euros(2345)).toBe('€2,345.00')
   })
 })
 

--- a/frontend/src/services/format.test.js
+++ b/frontend/src/services/format.test.js
@@ -1,0 +1,61 @@
+import { beforeEach, afterEach, describe, expect, test, it } from 'vitest'
+import { euros, date } from './format'
+import i18n from '../i18n/i18n'
+
+
+describe('euros formatting', () => {
+  it('amount with no decimals', () => {
+    expect(euros(2)).toBe('2,00 €')
+  })
+  it('amount with two decimals', () => {
+    expect(euros(2.15)).toBe('2,15 €')
+  })
+  it('amount with rounding up', () => {
+    expect(euros(2.159)).toBe('2,16 €')
+  })
+  it('amount with rounding down', () => {
+    expect(euros(2.151)).toBe('2,15 €')
+  })
+  it('amount with rounding middle', () => {
+    expect(euros(2.155)).toBe('2,16 €')
+  })
+  it('amount with negative', () => {
+    expect(euros(-2)).toBe('-2,00 €')
+  })
+  it('amount with string number', () => {
+    expect(euros('-2')).toBe('-2,00 €')
+  })
+  it('amount with undefined', () => {
+    expect(euros(undefined)).toBe('-- €')
+  })
+})
+
+
+describe('dates formatting', () => {
+  var previousLanguage
+  beforeEach(()=>{
+    previousLanguage = i18n.language
+  })
+  afterEach(()=>{
+    i18n.changeLanguage(previousLanguage)
+  })
+  it('default language (english)', () => {
+    expect(date('2022-12-20')).toBe('12/20/2022')
+  })
+  it('spanish', () => {
+    i18n.changeLanguage('es')
+    expect(date('2022-12-20')).toBe('20/12/2022')
+  })
+  it('euskara', () => {
+    i18n.changeLanguage('eu')
+    expect(date('2022-12-20')).toBe('2022/12/20')
+  })
+  it('undefined spanish', () => {
+    i18n.changeLanguage('es')
+    expect(date(undefined)).toBe('--/--/----')
+  })
+  it('undefined euskara', () => {
+    i18n.changeLanguage('eu')
+    expect(date(undefined)).toBe('----/--/--')
+  })
+})


### PR DESCRIPTION
## Description

Functions to use in order to format values received from domain according to value semantics and localization.

## Changes

- date: Formats isodates YYYY-mm-dd into the locale short form (d/m/yyyy in es,gl,ca and yyyy/m/d). Undefined turns digits into dashes ie. "--/--/----"

- euros: formats floats or string into 2 decimals with euro sign separated by nonbreakable space and using thousand separator. Current language is used to localize separators, decimal separators, currency and sign position... If something is not convertible into float "--  €" is shown.

- enum: Given a value and a map of enum option values to human localized text, chooses the option and behaves properly on undefined '-' or bad option '???'

## Observations

Those commits come from invoice list branch but we splitted them as a separated branch and PR so that they can be used in the concurrent installation details branch which also use enums, and will need to upgrade this module with localized percents and  numbers with units.

## Please, review

- Enum fallback. Now is "???". An alternative could be the enum value itself. What about a third optional parameter for fallback value? In this case, still, which could be the good default?


## How to check the new features

## Deploy notes


