### PR TITLE
✨ Manage pdf download errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Smart invoice pdf buttons (show progress, errors, completion)
 - Continuous integration enabled
 - Using component library
 - Animated error image

--- a/backend/datasources/erp.py
+++ b/backend/datasources/erp.py
@@ -21,6 +21,7 @@ from .exceptions import(
     ContractNotExists,
     UnauthorizedAccess,
     NoSuchUser,
+    NoSuchInvoice,
     NoDocumentVersions,
 )
 from .dummy import dummy_invoice_pdf
@@ -36,6 +37,7 @@ expected_erp_exceptions = [
     ContractNotExists,
     UnauthorizedAccess,
     NoSuchUser,
+    NoSuchInvoice,
     NoDocumentVersions,
 ]
 def process_erp_errors(erp_response):

--- a/backend/datasources/exceptions.py
+++ b/backend/datasources/exceptions.py
@@ -39,5 +39,8 @@ class UnauthorizedAccess(ErpError):
 class NoSuchUser(ErpError):
     pass
 
+class NoSuchInvoice(ErpError):
+    pass
+
 class NoDocumentVersions(ErpError):
     pass

--- a/frontend/src/i18n/locale-es.yaml
+++ b/frontend/src/i18n/locale-es.yaml
@@ -185,5 +185,8 @@ INVOICES:
   TOOLTIP_DOWNLOAD_ZIP: Descarga PDF's seleccionados en un ZIP
   NO_INVOICES: No se han encontrado facturas
   RELOAD: Recarga
+  DOWNLOAD_TOOLTIP_DOWNLOAD: Descarga
+  DOWNLOAD_TOOLTIP_SUCCESS: Descarga finalizada
+  DOWNLOAD_TOOLTIP_ONGOING: En proceso
 PRODUCTION:
   PRODUCTION_TITLE: Producción

--- a/frontend/src/i18n/locale-es.yaml
+++ b/frontend/src/i18n/locale-es.yaml
@@ -115,6 +115,7 @@ OVAPI:
   CONTEXT_INSTALLATION_DETAILS: Error obteniendo los detalles de la instalación
   CONTEXT_INVOICES: Error obteniendo la lista de facturas
   CONTEXT_SIGNING_DOCUMENT: Error aceptando condiciones
+  CONTEXT_INVOICE_PDF_DOWNLOAD: Error descargando la factura {{invoice}}
   ERR_UNABLE_TO_SIGN_DOCUMENT: 'No fue posible firmar el documento'
   ERR_NETWORK: No se encuentra el servidor. ¿Tienes conexión a la red?
   ERR_GATEWAY: El sistema no está disponible por mantenimiento. Prueba más tarde.

--- a/frontend/src/pages/InvoicesPage/DownloadButton.jsx
+++ b/frontend/src/pages/InvoicesPage/DownloadButton.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import IconButton from '@mui/material/IconButton'
+import CircularProgress from '@mui/material/CircularProgress'
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
+import CheckIcon from '@mui/icons-material/Check'
+import ErrorIcon from '@mui/icons-material/Error'
+import ovapi from '../../services/ovapi'
+
+const idle = 'idle'
+const done = 'done'
+const inprogress = 'inprogress'
+
+export default function DownloadButton({ context }) {
+  const [state, setState] = React.useState(idle)
+  const [error, setError] = React.useState(undefined)
+
+  async function onDownloadPdf() {
+    setState(inprogress)
+    setError(undefined)
+    try {
+      await ovapi.invoicePdf(context.invoice_number)
+      setState(done)
+    } catch (e) {
+      setState(done)
+      setError(error)
+    }
+  }
+  async function handleClick(ev) {
+    ev.stopPropagation()
+    if (state === inprogress) return
+    if (state === idle) return await onDownloadPdf()
+    setState(idle)
+    setError(undefined)
+  }
+
+  return (
+    <IconButton
+      size="small"
+      onClick={handleClick}
+      {...(state === done
+        ? {
+            color: error ? 'error' : 'success',
+          }
+        : null)}
+    >
+      {state === idle ? (
+        <PictureAsPdfIcon />
+      ) : state == inprogress ? (
+        <CircularProgress size={24} />
+      ) : error ? (
+        <ErrorIcon />
+      ) : (
+        <CheckIcon />
+      )}
+    </IconButton>
+  )
+}

--- a/frontend/src/pages/InvoicesPage/DownloadButton.jsx
+++ b/frontend/src/pages/InvoicesPage/DownloadButton.jsx
@@ -1,16 +1,19 @@
 import React from 'react'
 import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
 import CircularProgress from '@mui/material/CircularProgress'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import CheckIcon from '@mui/icons-material/Check'
 import ErrorIcon from '@mui/icons-material/Error'
+import { useTranslation } from 'react-i18next'
 import ovapi from '../../services/ovapi'
 
 const idle = 'idle'
 const done = 'done'
 const inprogress = 'inprogress'
 
-export default function DownloadButton({ context }) {
+export default function DownloadButton({ context, title }) {
+  const { t } = useTranslation()
   const [state, setState] = React.useState(idle)
   const [error, setError] = React.useState(undefined)
 
@@ -20,7 +23,7 @@ export default function DownloadButton({ context }) {
     try {
       await ovapi.invoicePdf(context.invoice_number)
       setState(done)
-    } catch (e) {
+    } catch (error) {
       setState(done)
       setError(error)
     }
@@ -33,25 +36,30 @@ export default function DownloadButton({ context }) {
     setError(undefined)
   }
 
+  const tooltip =
+    state === idle
+      ? title ?? t('INVOICES.DOWNLOAD_TOOLTIP_DOWNLOAD')
+      : state === inprogress
+      ? t('INVOICES.DOWNLOAD_TOOLTIP_ONGOING')
+      : error
+      ? error.error
+      : t('INVOICES.DOWNLOAD_TOOLTIP_SUCCESS')
+
+  const color = state !== done ? 'default' : error ? 'error' : 'success'
+
   return (
-    <IconButton
-      size="small"
-      onClick={handleClick}
-      {...(state === done
-        ? {
-            color: error ? 'error' : 'success',
-          }
-        : null)}
-    >
-      {state === idle ? (
-        <PictureAsPdfIcon />
-      ) : state == inprogress ? (
-        <CircularProgress size={24} />
-      ) : error ? (
-        <ErrorIcon />
-      ) : (
-        <CheckIcon />
-      )}
-    </IconButton>
+    <Tooltip title={tooltip} sx={{ backgroundColor: color }}>
+      <IconButton size="small" onClick={handleClick} {...{ color }}>
+        {state === idle ? (
+          <PictureAsPdfIcon />
+        ) : state == inprogress ? (
+          <CircularProgress size={24} />
+        ) : error ? (
+          <ErrorIcon />
+        ) : (
+          <CheckIcon />
+        )}
+      </IconButton>
+    </Tooltip>
   )
 }

--- a/frontend/src/pages/InvoicesPage/DownloadButton.md
+++ b/frontend/src/pages/InvoicesPage/DownloadButton.md
@@ -1,0 +1,7 @@
+DownloadButton starts a download and provides feedbacks about its state
+
+- As you press it, turns into a progress
+- When completed successful, green check
+- When error, red warning
+- Click on it again and you can try again
+

--- a/frontend/src/pages/InvoicesPage/index.jsx
+++ b/frontend/src/pages/InvoicesPage/index.jsx
@@ -106,8 +106,7 @@ export default function InvoicesPage(params) {
     },
   ]
   function onDownloadPdf(invoice) {
-    console.log('Hola', invoice.invoice_number)
-    window.location = `/api/invoice/${invoice.invoice_number}/pdf`
+    ovapi.invoicePdf(invoice.invoice_number)
   }
   const itemActions = [
     {

--- a/frontend/src/pages/InvoicesPage/index.jsx
+++ b/frontend/src/pages/InvoicesPage/index.jsx
@@ -110,7 +110,9 @@ export default function InvoicesPage(params) {
     {
       title: t('INVOICES.TOOLTIP_PDF'),
       icon: <PictureAsPdfIcon />,
-      view: (invoice) => <DownloadButton context={invoice} />,
+      view: (invoice) => (
+        <DownloadButton context={invoice} title={t('INVOICES.TOOLTIP_PDF')} />
+      ),
     },
   ]
   if (isLoading) return <Loading />

--- a/frontend/src/pages/InvoicesPage/index.jsx
+++ b/frontend/src/pages/InvoicesPage/index.jsx
@@ -15,6 +15,7 @@ import PageTitle from '../../components/PageTitle'
 import Loading from '../../components/Loading'
 import ErrorSplash from '../../components/ErrorSplash'
 import format from '../../services/format'
+import DownloadButton from './DownloadButton'
 //import dummyData from '../../data/dummyinvoices.yaml'
 
 export default function InvoicesPage(params) {
@@ -105,14 +106,11 @@ export default function InvoicesPage(params) {
       icon: <DownloadIcon />,
     },
   ]
-  function onDownloadPdf(invoice) {
-    ovapi.invoicePdf(invoice.invoice_number)
-  }
   const itemActions = [
     {
       title: t('INVOICES.TOOLTIP_PDF'),
       icon: <PictureAsPdfIcon />,
-      handler: onDownloadPdf,
+      view: (invoice) => <DownloadButton context={invoice} />,
     },
   ]
   if (isLoading) return <Loading />

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -259,9 +259,12 @@ function invoicePdf(invoiceNumber) {
       link.href = url
       const filename =
         result.headers['content-disposition'].match(/filename="([^"]+)"/)[1]
-      link.setAttribute('download', filename)
+      if (filename) link.setAttribute('download', filename)
       document.body.appendChild(link)
       link.click()
+      // clean up
+      document.body.removeChild(link)
+      url.revokeObjectURL(href)
       return result.data
     })
 }

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -264,7 +264,7 @@ function invoicePdf(invoiceNumber) {
       link.click()
       // clean up
       document.body.removeChild(link)
-      url.revokeObjectURL(href)
+      URL.revokeObjectURL(url)
       return result.data
     })
 }

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -242,6 +242,30 @@ async function invoices() {
     })
 }
 
+function invoicePdf(invoiceNumber) {
+  const context = i18n.t('OVAPI.CONTEXT_INVOICE_PDF_DOWNLOAD', { invoice: invoiceNumber })
+  return axios
+    .get(`/api/invoice/${invoiceNumber}/pdf`, {
+      responseType: 'blob',
+    })
+    .catch(handleCommonErrors(context))
+    .catch(handleRemainingErrors(context))
+    .then((result) => {
+      if (result.error !== undefined) {
+        throw result
+      }
+      const url = window.URL.createObjectURL(new Blob([result.data]))
+      const link = document.createElement('a')
+      link.href = url
+      const filename =
+        result.headers['content-disposition'].match(/filename="([^"]+)"/)[1]
+      link.setAttribute('download', filename)
+      document.body.appendChild(link)
+      link.click()
+      return result.data
+    })
+}
+
 export default {
   version,
   logout,
@@ -253,4 +277,5 @@ export default {
   installations,
   installationDetails,
   invoices,
+  invoicePdf,
 }


### PR DESCRIPTION
## Description

Turn pdf download into a managed axios query in order to manage errors

## Changes

- Instead of changing location delegate into axios and manage the response to generate a download
- Special button to handle state of each download

## Observations

![image](https://github.com/Som-Energia/somrepresenta-oficinavirtual/assets/532178/0752180d-478f-46f4-a8b3-546a85e75ee3)

## Please, review

- No regression:
    - Local file name is ok
    - PDF are opened in a diferent tab
    - PDF are opened as local file
- On error an error is displayed
    - Error not such user
    - Error not such invoice
    - Error not authorized (invoice  does not belong  to the user)
    - Connection error


## How to check the new featuresnot such user

## Deploy notes


