### PR TITLE
✨ Download zip file with invoices

### DIFF
--- a/backend/api_business.py
+++ b/backend/api_business.py
@@ -1,5 +1,6 @@
-from fastapi import Request, Depends, status
+from fastapi import Request, Depends, status, Query
 from fastapi.responses import JSONResponse
+from typing import Annotated
 from pydantic import AwareDatetime
 from .models import (
     UserProfile,
@@ -8,6 +9,7 @@ from .models import (
     InstallationDetailsResult,
     Invoice,
     InvoicePdf,
+    InvoicesZip,
     CustomerProductionData,
 )
 from .datasources import (
@@ -17,11 +19,12 @@ from .datasources import (
     installation_details,
     invoice_list,
     invoice_pdf,
+    invoices_zip,
     production_data,
 )
 from .erp import ErpConnectionError
 from .auth import validated_user
-from .utils.responses import PdfStreamingResponse
+from .utils.responses import PdfStreamingResponse, ZipStreamingResponse
 from consolemsg import error
 
 def setup_business(app):
@@ -60,10 +63,24 @@ def setup_business(app):
         response_class=PdfStreamingResponse,
     )
     def api_invoice_pdf(invoice_number: str, user: dict = Depends(validated_user)):
+        print('INVOICE_NUMBER ............',invoice_number)
         from yamlns import ns
         result: InvoicePdf = invoice_pdf(user['username'], invoice_number)
 
         return PdfStreamingResponse(
+            binary_data=result.content,
+            filename=result.filename,
+        )
+
+    @app.get(
+        '/api/invoices/zip',
+        response_class=ZipStreamingResponse,
+    )
+    def api_invoices_zip(invoice_numbers: Annotated[list[str], Query()] = None, user: dict = Depends(validated_user)):
+        from yamlns import ns
+        result: InvoicesZip = invoices_zip(user['username'], invoice_numbers[0].split(','))
+
+        return ZipStreamingResponse(
             binary_data=result.content,
             filename=result.filename,
         )

--- a/backend/api_business.py
+++ b/backend/api_business.py
@@ -63,7 +63,6 @@ def setup_business(app):
         response_class=PdfStreamingResponse,
     )
     def api_invoice_pdf(invoice_number: str, user: dict = Depends(validated_user)):
-        print('INVOICE_NUMBER ............',invoice_number)
         from yamlns import ns
         result: InvoicePdf = invoice_pdf(user['username'], invoice_number)
 

--- a/backend/datasources/__init__.py
+++ b/backend/datasources/__init__.py
@@ -68,7 +68,7 @@ def invoice_pdf(username: str, invoice_number: str) -> InvoicePdf:
     return backend().invoice_pdf(username, invoice_number)
 
 
-def invoices_zip(username: str, invoice_numbers: []) -> InvoicesZip:
+def invoices_zip(username: str, invoice_numbers: list[str]) -> InvoicesZip:
     return backend().invoices_zip(username, invoice_numbers)
 
 

--- a/backend/datasources/__init__.py
+++ b/backend/datasources/__init__.py
@@ -21,6 +21,7 @@ from ..models import (
     InstallationDetailsResult,
     Invoice,
     InvoicePdf,
+    InvoicesZip,
     CustomerProductionData,
 )
 from pydantic import AwareDatetime
@@ -65,6 +66,10 @@ def invoice_list(username: str) -> list[Invoice]:
 
 def invoice_pdf(username: str, invoice_number: str) -> InvoicePdf:
     return backend().invoice_pdf(username, invoice_number)
+
+
+def invoices_zip(username: str, invoice_numbers: []) -> InvoicesZip:
+    return backend().invoices_zip(username, invoice_numbers)
 
 
 def production_data(

--- a/backend/datasources/dummy.py
+++ b/backend/datasources/dummy.py
@@ -344,7 +344,7 @@ def zip_content(invoice_numbers):
     return base64.b64encode(zipfile_io.getvalue())
 
 
-def dummy_invoices_zip(username: str, invoice_numbers: []):
+def dummy_invoices_zip(username: str, invoice_numbers: list[str]):
     for invoice_number in invoice_numbers:
         if invoice_number in invoices_zip_exceptions:
             raise invoices_zip_exceptions[invoice_number](
@@ -414,7 +414,7 @@ class DummyBackend:
     def invoice_pdf(self, username: str, invoice_number: str) -> InvoicePdf:
         return dummy_invoice_pdf(username, invoice_number)
 
-    def invoices_zip(self, username: str, invoice_numbers: []) -> InvoicesZip:
+    def invoices_zip(self, username: str, invoice_numbers: list[str]) -> InvoicesZip:
         return dummy_invoices_zip(username, invoice_numbers)
 
     def production_data(

--- a/backend/datasources/dummy.py
+++ b/backend/datasources/dummy.py
@@ -12,6 +12,7 @@ from ..models import (
     InstallationDetailsResult,
     Invoice,
     InvoicePdf,
+    InvoicesZip,
     ProductionData,
     CustomerProductionData,
     ContractProductionData,
@@ -257,6 +258,16 @@ invoice_pdf_exceptions = {
     ]
 }
 
+invoices_zip_exceptions = {
+    e.__name__: e
+    for e in [
+        UnauthorizedAccess,
+        NoSuchUser,
+        ErpValidationError,
+        # TODO: ErpConnectionError,
+        # TODO: ErpUnexpectedError,
+    ]
+}
 
 def dummy_invoices(username: str) -> list[Invoice]:
     return [
@@ -291,7 +302,7 @@ def pdf_content(invoice_number):
         return output.getvalue()
 
 
-def dummy_invoice_pdf(username: str, invoice_number: str):
+def dummy_invoice_pdf(username: str, invoice_number: []):
     if invoice_number in invoice_pdf_exceptions:
         raise invoice_pdf_exceptions[invoice_number](
             dict(
@@ -307,6 +318,47 @@ def dummy_invoice_pdf(username: str, invoice_number: str):
         content_type="application/pdf",
     )
 
+
+def zip_content(invoice_numbers):
+    import zipfile
+    from xhtml2pdf import pisa
+    import io
+
+    zipfile_io = io.BytesIO()
+    zipfile_ = zipfile.ZipFile(zipfile_io, "w")
+
+    for invoice_number in invoice_numbers:
+        html = f"""
+            <style>h1 {{font-size: 4rem}}</style>
+            <h1>Factura {invoice_number}</h1>
+        """
+        with io.BytesIO() as output:
+            pisa.CreatePDF(
+                src=html,
+                dest=output,
+            )
+            zipfile_.writestr(invoice_number, output.getvalue())
+
+    zipfile_.close()
+            
+    return base64.b64encode(zipfile_io.getvalue())
+
+
+def dummy_invoices_zip(username: str, invoice_numbers: []):
+    for invoice_number in invoice_numbers:
+        if invoice_number in invoices_zip_exceptions:
+            raise invoices_zip_exceptions[invoice_number](
+                dict(
+                    code=invoice_number,
+                    error=f"{invoice_number} (Dummy error)",
+                )
+            )
+
+    return InvoicesZip(
+        content=zip_content(invoice_numbers),
+        filename=f"{username}_invoices_from_{invoice_numbers[0]}.zip",
+        content_type="application/zip",
+    )
 
 
 def dummy_production_data(
@@ -361,6 +413,9 @@ class DummyBackend:
 
     def invoice_pdf(self, username: str, invoice_number: str) -> InvoicePdf:
         return dummy_invoice_pdf(username, invoice_number)
+
+    def invoices_zip(self, username: str, invoice_numbers: []) -> InvoicesZip:
+        return dummy_invoices_zip(username, invoice_numbers)
 
     def production_data(
         self,

--- a/backend/datasources/erp.py
+++ b/backend/datasources/erp.py
@@ -10,6 +10,7 @@ from ..models import (
     InstallationDetailsResult,
     Invoice,
     InvoicePdf,
+    InvoicesZip,
     CustomerProductionData,
 )
 from .. import erp
@@ -118,6 +119,12 @@ def erp_invoice_pdf(username: str, invoice_number: str) -> InvoicePdf:
     with catch_validation_error():
         return InvoicePdf(**pdffile)
 
+def erp_invoices_zip(username: str, invoice_numbers: []) -> InvoicesZip:
+    e = erp.Erp()
+    zipfile = e.invoices_zip(username, invoice_numbers)
+    process_erp_errors(zipfile)
+    with catch_validation_error():
+        return InvoicesZip(**zipfile)
 
 def erp_production_data(
         username: str,
@@ -154,6 +161,9 @@ class ErpBackend:
 
     def invoice_pdf(self, username: str, invoice_number: str) -> InvoicePdf:
         return erp_invoice_pdf(username, invoice_number)
+
+    def invoices_zip(self, username: str, invoice_numbers: []) -> InvoicesZip:
+        return erp_invoices_zip(username, invoice_numbers)
 
     def production_data(
         self,

--- a/backend/datasources/erp.py
+++ b/backend/datasources/erp.py
@@ -119,7 +119,7 @@ def erp_invoice_pdf(username: str, invoice_number: str) -> InvoicePdf:
     with catch_validation_error():
         return InvoicePdf(**pdffile)
 
-def erp_invoices_zip(username: str, invoice_numbers: []) -> InvoicesZip:
+def erp_invoices_zip(username: str, invoice_numbers: list[str]) -> InvoicesZip:
     e = erp.Erp()
     zipfile = e.invoices_zip(username, invoice_numbers)
     process_erp_errors(zipfile)
@@ -162,7 +162,7 @@ class ErpBackend:
     def invoice_pdf(self, username: str, invoice_number: str) -> InvoicePdf:
         return erp_invoice_pdf(username, invoice_number)
 
-    def invoices_zip(self, username: str, invoice_numbers: []) -> InvoicesZip:
+    def invoices_zip(self, username: str, invoice_numbers: list[str]) -> InvoicesZip:
         return erp_invoices_zip(username, invoice_numbers)
 
     def production_data(

--- a/backend/erp.py
+++ b/backend/erp.py
@@ -133,7 +133,7 @@ class Erp:
             "som.ov.invoices", "download_invoice_pdf", username, invoice_number
         )
 
-    def invoices_zip(self, username: str, invoice_numbers: []) -> dict:
+    def invoices_zip(self, username: str, invoice_numbers: list[str]) -> dict:
         return self.object_execute(
             "som.ov.invoices", "download_invoices_zip", username, invoice_numbers
         )

--- a/backend/erp.py
+++ b/backend/erp.py
@@ -133,6 +133,11 @@ class Erp:
             "som.ov.invoices", "download_invoice_pdf", username, invoice_number
         )
 
+    def invoices_zip(self, username: str, invoice_numbers: []) -> dict:
+        return self.object_execute(
+            "som.ov.invoices", "download_invoices_zip", username, invoice_numbers
+        )
+
     def production_data(self, username: str, first_timestamp_utc: AwareDatetime, last_timestamp_utc: AwareDatetime):
         data = self.object_execute(
             "som.ov.production.data",

--- a/backend/models.py
+++ b/backend/models.py
@@ -156,6 +156,14 @@ class InvoicePdf(BaseModel):
     content_type: str # TODO: content type check
     filename: str
 
+class ListOfInvoiceNumbers(BaseModel):
+    invoice_numbers: list[str]
+
+class InvoicesZip(BaseModel):
+    content: Base64Bytes
+    content_type: str # TODO: content type check
+    filename: str
+
 class ProductionData(BaseModel):
     data: str
     value: int

--- a/backend/models.py
+++ b/backend/models.py
@@ -156,9 +156,6 @@ class InvoicePdf(BaseModel):
     content_type: str # TODO: content type check
     filename: str
 
-class ListOfInvoiceNumbers(BaseModel):
-    invoice_numbers: list[str]
-
 class InvoicesZip(BaseModel):
     content: Base64Bytes
     content_type: str # TODO: content type check

--- a/backend/utils/responses.py
+++ b/backend/utils/responses.py
@@ -17,3 +17,19 @@ class PdfStreamingResponse(StreamingResponse):
             },
             **kwds)
 
+class ZipStreamingResponse(StreamingResponse):
+    media_type='application/zip'
+
+    def __init__(self, binary_data: bytes, filename: str, **kwds):
+        def binary_stream(binary_data):
+            import io
+            with io.BytesIO(binary_data) as f:
+                yield from f
+
+        super().__init__(
+            binary_stream(binary_data),
+            headers = {
+                'Content-Disposition': f'attachment; filename="{filename}"',
+            },
+            **kwds)
+

--- a/frontend/src/i18n/locale-ca.yaml
+++ b/frontend/src/i18n/locale-ca.yaml
@@ -103,7 +103,7 @@ CONTRACT_DETAIL:
   BILLING_MODE: Mode de facturació
   CONTRACT_DETAILS_TITLE: Detalls del contracte
   REPRESENTATION_TYPE: Tipus de representació
-  PROXY_FEE: Retribució per al servei de representació [€/MWh]
+  PROXY_FEE: Retribució per al servei de representació
   IBAN: IBAN
   STATUS: Estat del contracte
   REDUCTION_DEVIATION: Reducció dels desviaments per efecte de cartera
@@ -116,12 +116,12 @@ INSTALLATION_DETAIL:
   INSTALLATION_DETAILS_TITLE: Detalls de la instal·lació
   COORDINATES: Coordenades
   MINISTRY_CODE: Codi del Ministeri
-  NAME: Nom
+  NAME: Nom de la instal·lació
   POSTAL_CODE: Codi postal
   PROVINCE: Província
   CONTRACT_DETAILS_TITLE: Detalls del contracte
   CITY: Municipi
-  CONTRACT_NUMBER: Contracte
+  CONTRACT_NUMBER: Núm. de contracte
   ADDRESS: Adreça
   CIL: CIL
 INSTALLATIONS:
@@ -163,7 +163,7 @@ COOKIES_POLICY:
   SESSION_COOKIES: Cookies de sessió
   SESSION_COOKIES_DESCRIPTION: Les cookies de sessió són aquelles que duren el temps que la persona usuària està navegant per la pàgina web i s’esborren quan es tanca el navegador.
   PERSISTENT_COOKIES: Cookies persistents
-  PERSISTENT_COOKIES_DESCRIPTION: Les cookies de sessió són aquelles que duren el temps que la persona usuària està navegant per la pàgina web i s’esborren quan es tanca el navegador.
+  PERSISTENT_COOKIES_DESCRIPTION: Aquestes cookies queden emmagatzemades en el terminal de la usuària o usuari fins que són eliminades manualment o acabi el període de durada establert per a aquesta galeta.
   OWN_COOKIES: Cookies pròpies
   OWN_COOKIES_DESCRIPTION: Aquelles que s’envien a l’equip terminal de l’usuari o usuària des d’un equip o domini gestionat pel mateix editor o editora i des del qual es presta el servei sol·licitat per la persona usuària.
   THIRDPARTY_COOKIES: Cookies de tercers
@@ -173,7 +173,7 @@ COOKIES_POLICY:
   PERFORMANCE: RENDIMENT
   PERFORMANCE_DESCRIPTION: Cookies Tècniques pròpies i persistens. Cookies de Personalització pròpies o de tercers, de sessió o persistents.
   STATISTICS: ESTADÍSTICA
-  STATISTICS_DESCRIPTION: Cookies Analítiques i Pulicitàries persistents, pròpies i de tercers.
+  STATISTICS_DESCRIPTION: Cookies Analítiques i Publicitàries persistents, pròpies i de tercers.
   FUNCTIONALITY: FUNCIONALITAT
   FUNCTIONALITY_DESCRIPTION: Cookies Tècniques de tercers, de sessió o persistents.
   CHROME_DESACTIVATE_COOKIES: Configuració > Mostrar opcions avançades > Privacitat > Configuració de contingut.

--- a/frontend/src/i18n/locale-es.yaml
+++ b/frontend/src/i18n/locale-es.yaml
@@ -126,6 +126,7 @@ OVAPI:
   CONTEXT_INVOICES: Error obteniendo la lista de facturas
   CONTEXT_SIGNING_DOCUMENT: Error aceptando condiciones
   CONTEXT_INVOICE_PDF_DOWNLOAD: Error descargando la factura {{invoice}}
+  CONTEXT_INVOICES_ZIP_DOWNLOAD: Error descargando el zip de las facturas {{invoice_numbers}}
   ERR_UNABLE_TO_SIGN_DOCUMENT: 'No fue posible firmar el documento'
   ERR_NETWORK: No se encuentra el servidor. ¿Tienes conexión a la red?
   ERR_GATEWAY: El sistema no está disponible por mantenimiento. Prueba más tarde.

--- a/frontend/src/i18n/locale-es.yaml
+++ b/frontend/src/i18n/locale-es.yaml
@@ -137,10 +137,10 @@ INSTALLATION_DETAIL:
   CONTRACT_DETAILS_TITLE: Detalles del contrato
   ADDRESS: Dirección
   CITY: Municipio
-  CONTRACT_NUMBER: Contrato
+  CONTRACT_NUMBER: N.º de contrato
   COORDINATES: Coordenadas
   MINISTRY_CODE: Código del Ministerio
-  NAME: Nombre
+  NAME: Nombre de la instalación
   POSTAL_CODE: Código postal
   PROVINCE: Provincia
   RATED_POWER: Potencia nominal
@@ -232,42 +232,42 @@ PRODUCTION:
   MATURITY_HC: Final definitiva (HC)
 COOKIES_POLICY:
   TITLE: Política de cookies
-  SUBTITLE: Quin ús fem dels tipus de cookies?
-  PURPOSE: Segons la finalitat
-  TERM: Segons el seu termini
-  OWNERSHIP: Segons la seva titularitat
-  TABLE_DESCRIPTION: La taula següent recull la classificació i descripció de les galetes utilitzades en la present pàgina web perquè pugueu identificar-les en el vostre navegador
-  TABLE_COOKIES_CLASSIFICATION: Les cookies es poden classificar en diferents paràmetres, és a dir, segons la seva funció, titularitat i terminis. Seguint aquesta classificació, i per tal que la informació proporcionada sigui el més transparent possible, SOM ENERGIA ha elaborat aquesta taula que recull tota la informació i descripció de les cookies utilitzades d’acord amb la següent classificació
-  SOM_COOKIES: SOM ENERGIA utilitza galetes tècniques, de personalització, anàlisi i publicitàries, pròpies i de tercers, que tracten dades de connexió i/o de dispositiu, així com hàbits de navegació per a finalitats estadístiques i publicitàries.
-  SOM_COOKIES_EXPLANATION: Per això, en accedir al nostre web, en compliment de l’article 22 de la Llei de serveis de la societat de la informació, hem sol·licitat el vostre consentiment per al seu ús. El subministrament de dades personals a través del nostre portal i el consentiment per a l’ús de galetes requereix una edat mínima de 18 anys i l’acceptació expressa de la nostra política de privacitat.
-  DEACTIVATE_COOKIES_TABLE: De tota manera, us informem que podeu activar o desactivar les galetes seguint les instruccions del vostre navegador d’Internet
-  TECHNICAL_COOKIES: Cookies tècniques
-  TECHNICAL_COOKIES_DESCRIPTION: Les cookies tècniques són aquelles que faciliten la navegació de la persona usuària i la utilització de les diferents opcions o serveis que ofereix el web, com ara identificar la sessió, permetre l’accés a determinades àrees, facilitar comandes, compres, omplir formularis, inscripcions, seguretat, facilitar funcionalitats (vídeos, xarxes socials,...).
-  CUSTOMIZATION_COOKIES: Cookies de personalització
-  CUSTOMIZATION_COOKIES_DESCRIPTION: Les cookies de personalització permeten a la persona usuària accedir als serveis segons les seves preferències (llengua, navegador, configuració,...).
-  ANALYTICS_COOKIES: Cookies analítiques
-  ANALYTICS_COOKIES_DESCRIPTION: Les cookies d’anàlisi són les utilitzades per dur a terme l’anàlisi anònima del comportament de les persones usuàries del web i que permeten mesurar l’activitat de la usuària o usuari, i elaborar perfils de navegació amb l’objectiu de millorar els llocs web.
-  ADVERTISING_COOKIES: Cookies publicitàries
-  ADVERTISING_COOKIES_DESCRIPTION: Les cookies publicitàries permeten la gestió dels espais publicitaris del web. A més, aquestes cookies poden ser de publicitat personalitzada i permetre així la gestió dels espais publicitaris del web basant-se en el comportament i els hàbits de navegació de la usuària o usuari, d’on se n’obté el perfil, i permeten personalitzar la publicitat que es mostra en el navegador de la persona usuària, o bé altres perfils i xarxes socials de l’usuari o usuària.
-  SESSION_COOKIES: Cookies de sessió
-  SESSION_COOKIES_DESCRIPTION: Les cookies de sessió són aquelles que duren el temps que la persona usuària està navegant per la pàgina web i s’esborren quan es tanca el navegador.
-  PERSISTENT_COOKIES: Cookies persistents
-  PERSISTENT_COOKIES_DESCRIPTION: Les cookies de sessió són aquelles que duren el temps que la persona usuària està navegant per la pàgina web i s’esborren quan es tanca el navegador.
-  OWN_COOKIES: Cookies pròpies
-  OWN_COOKIES_DESCRIPTION: Aquelles que s’envien a l’equip terminal de l’usuari o usuària des d’un equip o domini gestionat pel mateix editor o editora i des del qual es presta el servei sol·licitat per la persona usuària.
-  THIRDPARTY_COOKIES: Cookies de tercers
-  THIRDPARTY_COOKIES_DESCRIPTION: Aquelles que s’envien a l’equip terminal de la persona usuària des d’un equip o domini que no és gestionat per l’editor o editora, sinó per una altra entitat que tracta les dades obtingudes mitjançant les cookies.
-  BASIC: BÀSIQUES
-  BASIC_DESCRIPTION: Cookies Tècniques pròpies i de sessió.
-  PERFORMANCE: RENDIMENT
-  PERFORMANCE_DESCRIPTION: Cookies Tècniques pròpies i persistens. Cookies de Personalització pròpies o de tercers, de sessió o persistents.
+  SUBTITLE: Qué uso hacemos de los tipos de cookies?
+  PURPOSE: Según la finalidad
+  TERM: Según su plazo
+  OWNERSHIP: Según su titularidad
+  TABLE_DESCRIPTION: La siguiente tabla recoge la clasificación y descripción de las cookies utilizadas en la presente página web para que pueda identificarlas en su navegador
+  TABLE_COOKIES_CLASSIFICATION: Las cookies pueden clasificarse en diferentes parámetros, es decir, según su función, titularidad y plazos. Siguiendo esta clasificación, y para que la información proporcionada sea lo más transparente posible, SOM ENERGIA ha elaborado esta tabla que recoge toda la información y descripción de las cookies utilizadas de acuerdo con la siguiente clasificación
+  SOM_COOKIES: SOMOS ENERGÍA utiliza cookies técnicas, de personalización, análisis y publicitarias, propias y de terceros, que tratan datos de conexión y/o de dispositivo, así como hábitos de navegación para fines estadísticos y publicitarios.
+  SOM_COOKIES_EXPLANATION: Por ello, al acceder a nuestra web, en cumplimiento del artículo 22 de la Ley de servicios de la sociedad de la información, hemos solicitado su consentimiento para su uso. El suministro de datos personales a través de nuestro portal y el consentimiento para el uso de cookies requiere una edad mínima de 18 años y aceptación expresa de nuestra política de privacidad.
+  DEACTIVATE_COOKIES_TABLE: De todas formas, le informamos que puede activar o desactivar las cookies siguiendo las instrucciones de su navegador de Internet
+  TECHNICAL_COOKIES: Cookies técnicas
+  TECHNICAL_COOKIES_DESCRIPTION: Las cookies técnicas son aquellas que facilitan la navegación de la persona usuaria y la utilización de las diferentes opciones o servicios que ofrece la web, como por ejemplo identificar la sesión, permitir el acceso a determinadas áreas, facilitar pedidos, compras, rellenar formularios, inscripciones , seguridad, facilitar funcionalidades (vídeos, redes sociales,...).
+  CUSTOMIZATION_COOKIES: Cookies de personalización
+  CUSTOMIZATION_COOKIES_DESCRIPTION: Las cookies de personalización permiten al usuario acceder a los servicios según sus preferencias (lengua, navegador, configuración,...).
+  ANALYTICS_COOKIES: Cookies analíticas
+  ANALYTICS_COOKIES_DESCRIPTION: Las cookies de análisis son las utilizadas para llevar a cabo el análisis anónimo del comportamiento de las personas usuarias de la web y que permiten medir la actividad de la usuaria o usuario, y elaborar perfiles de navegación con el objetivo de mejorar los sitios web.
+  ADVERTISING_COOKIES: Cookies publicitarias
+  ADVERTISING_COOKIES_DESCRIPTION: Las cookies publicitarias permiten la gestión de los espacios publicitarios de la web. Además, estas cookies pueden ser de publicidad personalizada y permitir así la gestión de los espacios publicitarios de la web en base al comportamiento y los hábitos de navegación de la usuaria o usuario, de donde se obtiene el perfil, y permiten personalizar la publicidad que se muestra en el navegador de la persona usuaria, u otros perfiles y redes sociales del usuario o usuaria.
+  SESSION_COOKIES: Cookies de sesión
+  SESSION_COOKIES_DESCRIPTION: Las cookies de sesión son aquellas que duran el tiempo que la persona usuaria está navegando por la página web y se borran cuando se cierra el navegador.
+  PERSISTENT_COOKIES: Cookies persistentes
+  PERSISTENT_COOKIES_DESCRIPTION: Estas cookies quedan almacenadas en el terminal de la usuaria o usuario hasta que son eliminadas manualmente o termine el período de duración establecido para esta cookie.
+  OWN_COOKIES: Cookies propias
+  OWN_COOKIES_DESCRIPTION: Aquellas que se envíen al equipo terminal del usuario o usuaria desde un equipo o dominio gestionado por el propio editor o editora y desde el que se presta el servicio solicitado por el usuario.
+  THIRDPARTY_COOKIES: Cookies de terceros
+  THIRDPARTY_COOKIES_DESCRIPTION: Aquellas que se envíen al equipo terminal de la persona usuaria desde un equipo o dominio que no es gestionado por el editor o editora, sino por otra entidad que trata los datos obtenidos mediante las cookies.
+  BASIC: BÁSICAS
+  BASIC_DESCRIPTION: Cookies Técnicas propias y de sesión.
+  PERFORMANCE: RENDIMIENTO
+  PERFORMANCE_DESCRIPTION: Cookies Técnicas propias y persistentes. Cookies de Personalización propias o de terceros, de sesión o persistentes.
   STATISTICS: ESTADÍSTICA
-  STATISTICS_DESCRIPTION: Cookies Analítiques i Pulicitàries persistents, pròpies i de tercers.
-  FUNCTIONALITY: FUNCIONALITAT
-  FUNCTIONALITY_DESCRIPTION: Cookies Tècniques de tercers, de sessió o persistents.
-  CHROME_DESACTIVATE_COOKIES: Configuració > Mostrar opcions avançades > Privacitat > Configuració de contingut.
-  FIREFOX_DESACTIVATE_COOKIES: Eines > Opcions > Privacitat > Historial > Configuració personalitzada.
-  EXPLORER_DESACTIVATE_COOKIES: Eines > Opcions d’Internet > Privacitat > Configuració.
-  OPERA_DESACTIVATE_COOKIES: Eines > Preferències > Editar preferències > Cookies
-  SAFARI_DESACTIVATE_COOKIES: Preferències > Seguretat.
-  EDGE_DESACTIVATE_COOKIES: Configuració > Vegeu configuració avançada > Privacitat i serveis > Cookies.
+  STATISTICS_DESCRIPTION: Cookies Analíticas y Publicitarias persistentes, propias y de terceros.
+  FUNCTIONALITY: FUNCIONALIDAD
+  FUNCTIONALITY_DESCRIPTION: Cookies Técnicas de terceros, de sesión o persistentes.
+  CHROME_DESACTIVATE_COOKIES: Configuración > Mostrar opciones avanzades > Privacidad > Configuración de contenido
+  FIREFOX_DESACTIVATE_COOKIES: Herramientas > Opciones > Privacidad > Historial > Configuración personalizada.
+  EXPLORER_DESACTIVATE_COOKIES: Herramientas > Opciones de Internet > Privacidad > Configuración
+  OPERA_DESACTIVATE_COOKIES: Herramientas > Preferencias > Editar Preferencias > Cookies
+  SAFARI_DESACTIVATE_COOKIES: Preferencias > Seguridad.
+  EDGE_DESACTIVATE_COOKIES: Configuración > Véase configuración avanzada > Privacidad y servicios > Cookies.

--- a/frontend/src/i18n/locale-eu.yaml
+++ b/frontend/src/i18n/locale-eu.yaml
@@ -1,1 +1,48 @@
-{}
+APP_FRAME:
+  PAGE_INSTALLATIONS: Instalazioak
+  PAGE_INVOICES: Fakturak
+  PAGE_PRODUCTION_DATA: Ekoizpen
+INSTALLATIONS:
+  INSTALLATIONS_TITLE: Instalazioak
+  TABLE_TITLE: '{{n}} instalazioak'
+  COLUMN_CONTRACT_NUMBER: Kontratu-zenbakia
+  COLUMN_INSTALLATION_NAME: Instalazioaren izena
+  BUTTON_DETAILS: Xehetasunak
+  TOOLTIP_DETAILS: Xehetasunak
+INSTALLATION_DETAIL:
+  DETAILS_TITLE: Xehetasunak
+  INSTALLATION_DETAILS_TITLE: Instalazioaren gaineko informazioa
+  CONTRACT_DETAILS_TITLE: Kontratuaren gaineko informazioa
+  ADDRESS: Helbidea
+  CITY: Udalerria
+  CONTRACT_NUMBER: Kontratu-zenbakia
+  COORDINATES: Koordenatuak
+  MINISTRY_CODE: Ministerioaren kodea
+  NAME: Instalazioaren izena
+  POSTAL_CODE: Posta-kodea
+  PROVINCE: Probintzia
+  RATED_POWER: Potentzia nominala
+  TECHNOLOGY: Teknologia
+  CIL: CIL
+CONTRACT_DETAIL:
+  CONTRACT_DETAILS_TITLE: Kontratuaren gaineko informazioa
+  BILLING_MODE: Fakturazio-modua
+  COST_DEVIATION: Desbideraketen kostua
+  DISCHARGE_DATE: Alta-data
+  IBAN: IBAN
+  PROXY_FEE: Ordezkaritza-zerbitzuaren ordainsaria
+  REPRESENTATION_TYPE: Ordezkaritza-mota
+  STATUS: Kontratuaren egoera
+INVOICES:
+  INVOICES_TITLE: Fakturak
+  TABLE_TITLE: '{{n}} fakturak'
+  COLUMN_PERIOD: Denboraldia
+  COLUMN_AMOUNT: Zenbatekoa
+  COLUMN_LIQUIDATION: Likidazioa
+  CONCEPT_OPTION_MARKET: Merkatua
+  CONCEPT_OPTION_SPECIFIC_RETRIBUTION: Ordainsari espezifikoa
+  CONCEPT_OPTION_SERVICES: Zerbitzuak
+PRODUCTION:
+  PRODUCTION_TITLE: Ekoizpen
+  LEGEND_PRODUCTION: Ekoizpen (kWh)
+  LEGEND_FORESEEN: Aurreikuspena (kWh)

--- a/frontend/src/i18n/locale-gl.yaml
+++ b/frontend/src/i18n/locale-gl.yaml
@@ -1,1 +1,48 @@
-{}
+APP_FRAME:
+  PAGE_INSTALLATIONS: Instalacións
+  PAGE_INVOICES: Facturas
+  PAGE_PRODUCTION_DATA: Produción
+INSTALLATIONS:
+  INSTALLATIONS_TITLE: Instalacións
+  TABLE_TITLE: '{{n}} instalacións'
+  COLUMN_CONTRACT_NUMBER: N.º de contrato
+  COLUMN_INSTALLATION_NAME: Nome da instalación
+  BUTTON_DETAILS: Detalles
+  TOOLTIP_DETAILS: Detalles
+INSTALLATION_DETAIL:
+  DETAILS_TITLE: Detalles
+  INSTALLATION_DETAILS_TITLE: Detalle da instalación
+  CONTRACT_DETAILS_TITLE: Detalle do contrato
+  ADDRESS: Enderezo
+  CITY: Concello
+  CONTRACT_NUMBER: N.º de contrato
+  COORDINATES: Coordenadas
+  MINISTRY_CODE: Código do Ministerio
+  NAME: Nome da instalación
+  POSTAL_CODE: Código postal
+  PROVINCE: Provincia
+  RATED_POWER: Potencia nominal
+  TECHNOLOGY: Tecnoloxía
+  CIL: CIL
+CONTRACT_DETAIL:
+  CONTRACT_DETAILS_TITLE: Detalle do contrato
+  BILLING_MODE: Modo de facturación
+  COST_DEVIATION: Custo dos desvíos
+  DISCHARGE_DATE: Data da alta
+  IBAN: IBAN
+  PROXY_FEE: Retribución polo servizo de representación
+  REPRESENTATION_TYPE: Tipo de representación
+  STATUS: Estado do contrato
+INVOICES:
+  INVOICES_TITLE: Facturas
+  TABLE_TITLE: '{{n}} facturas'
+  COLUMN_PERIOD: Período
+  COLUMN_AMOUNT: Importe
+  COLUMN_LIQUIDATION: Liquidación
+  CONCEPT_OPTION_MARKET: Mercado
+  CONCEPT_OPTION_SPECIFIC_RETRIBUTION: Retribución específica
+  CONCEPT_OPTION_SERVICES: Servizos
+PRODUCTION:
+  PRODUCTION_TITLE: Produción
+  LEGEND_PRODUCTION: Produción (kWh)
+  LEGEND_FORESEEN: Previsión (kWh)

--- a/frontend/src/pages/InvoicesPage/DownloadButton.jsx
+++ b/frontend/src/pages/InvoicesPage/DownloadButton.jsx
@@ -22,7 +22,6 @@ export default function DownloadButton({ context, title }) {
     setState(inprogress)
     setError(undefined)
     try {
-      console.log('INVOICE_NUMBER ',context)
       await ovapi.invoicePdf(context.invoice_number)
       setState(done)
     } catch (error) {

--- a/frontend/src/pages/InvoicesPage/DownloadZipButton.jsx
+++ b/frontend/src/pages/InvoicesPage/DownloadZipButton.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import CircularProgress from '@mui/material/CircularProgress'
-import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
+import DownloadIcon from '@mui/icons-material/Download'
 import CheckIcon from '@mui/icons-material/Check'
 import ErrorIcon from '@mui/icons-material/Error'
 import { useTranslation } from 'react-i18next'
@@ -13,17 +13,16 @@ const idle = 'idle'
 const done = 'done'
 const inprogress = 'inprogress'
 
-export default function DownloadButton({ context, title }) {
+export default function DownloadZipButton({ context, title }) {
   const { t } = useTranslation()
   const [state, setState] = React.useState(idle)
   const [error, setError] = React.useState(undefined)
 
-  async function onDownloadPdf() {
+  async function onDownloadZip() {
     setState(inprogress)
     setError(undefined)
     try {
-      console.log('INVOICE_NUMBER ',context)
-      await ovapi.invoicePdf(context.invoice_number)
+      await ovapi.invoicesZip(context)
       setState(done)
     } catch (error) {
       setState(done)
@@ -33,14 +32,14 @@ export default function DownloadButton({ context, title }) {
   async function handleClick(ev) {
     ev.stopPropagation()
     if (state === inprogress) return
-    if (state === idle) return await onDownloadPdf()
+    if (state === idle) return await onDownloadZip()
     setState(idle)
     setError(undefined)
   }
 
   const tooltip =
     state === idle
-      ? title ?? t('INVOICES.DOWNLOAD_TOOLTIP_DOWNLOAD')
+      ? title ?? t('INVOICES.TOOLTIP_DOWNLOAD_ZIP')
       : state === inprogress
         ? t('INVOICES.DOWNLOAD_TOOLTIP_ONGOING')
         : error
@@ -53,7 +52,7 @@ export default function DownloadButton({ context, title }) {
     <Tooltip title={tooltip} sx={{ backgroundColor: color }}>
       <IconButton size="small" onClick={handleClick} {...{ color }}>
         {state === idle ? (
-          <PictureAsPdfIcon />
+          <DownloadIcon />
         ) : state == inprogress ? (
           <CircularProgress size={24} />
         ) : error ? (

--- a/frontend/src/pages/InvoicesPage/DownloadZipButton.md
+++ b/frontend/src/pages/InvoicesPage/DownloadZipButton.md
@@ -1,0 +1,7 @@
+DownloadZipButton starts a download and provides feedbacks about its state
+
+- As you press it, turns into a progress
+- When completed successful, green check
+- When error, red warning
+- Click on it again and you can try again
+

--- a/frontend/src/pages/InvoicesPage/index.jsx
+++ b/frontend/src/pages/InvoicesPage/index.jsx
@@ -20,6 +20,7 @@ import Loading from '../../components/Loading'
 import ErrorSplash from '../../components/ErrorSplash'
 import format from '../../services/format'
 import DownloadButton from './DownloadButton'
+import DownloadZipButton from './DownloadZipButton'
 
 
 function PaymentCell({payment_status}) {
@@ -141,6 +142,9 @@ export default function InvoicesPage() {
     {
       title: t('INVOICES.TOOLTIP_DOWNLOAD_ZIP'),
       icon: <DownloadIcon />,
+      view: (invoices) => (
+        <DownloadZipButton context={invoices} title={t('INVOICES.TOOLTIP_DOWNLOAD_ZIP')} />
+      ),
     },
   ]
   const itemActions = [

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -312,7 +312,7 @@ function invoicesZip(invoiceNumbers) {
         const filename =
           result.headers['content-disposition']?.match(/filename="([^"]+)"/)[1] ??
           `facturas-from${chunk[0]}.zip`
-        downloadZipFile(filename, result.data, 'application/zip')
+          downloadBlob(filename, result.data, 'application/zip')
       })
   }
 }

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -295,7 +295,6 @@ function invoicesZip(invoiceNumbers) {
   
     const chunk = invoiceNumbers.slice(i, i + chunkSize)
     const context = i18n.t('OVAPI.CONTEXT_INVOICES_ZIP_DOWNLOAD', { invoice_numbers: chunk})
-    console.log('context-----',context)
 
     const queryParams = '?invoice_numbers=' + chunk
 

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -289,6 +289,35 @@ function invoicePdf(invoiceNumber) {
     })
 }
 
+function invoicesZip(invoiceNumbers) {
+  const chunkSize = 12 //creates zip of 12 invoices (1 year)
+  for (let i = 0; i < invoiceNumbers.length; i += chunkSize){
+  
+    const chunk = invoiceNumbers.slice(i, i + chunkSize)
+    const context = i18n.t('OVAPI.CONTEXT_INVOICES_ZIP_DOWNLOAD', { invoice_numbers: chunk})
+    console.log('context-----',context)
+
+    const queryParams = '?invoice_numbers=' + chunk
+
+    axios
+      .get(`/api/invoices/zip${queryParams}`, {
+        responseType: 'arraybuffer',
+      })
+      .catch(handleCommonErrors(context))
+      .catch(handleRemainingErrors(context))
+      .then((result) => {
+        if (result.error !== undefined) {
+          throw result
+        }
+
+        const filename =
+          result.headers['content-disposition']?.match(/filename="([^"]+)"/)[1] ??
+          `facturas-from${chunk[0]}.zip`
+        downloadZipFile(filename, result.data, 'application/zip')
+      })
+  }
+}
+
 async function productionData(first_timestamp_utc, last_timestamp_utc) {
   const context = i18n.t('OVAPI.CONTEXT_PRODUCTION_DATA')
   return axios
@@ -318,5 +347,6 @@ export default {
   installationDetails,
   invoices,
   invoicePdf,
+  invoicesZip,
   productionData,
 }


### PR DESCRIPTION
## Description

Allow to download a zip file with selected invoices. Several zip are generated with maximum lenght of 12 invoice  pdfs by zip file.

## Changes

- Add necessary backend to call erp method download_invoices_zip in som_ov_invoices of somrepresenta-erp-modules repository
- Add a call that gestionate the numeber of zip created
- Add dummy to test in local
- Add a model InvoicesZip
- Add DownloadZipButton funcionality

## Please, review

- Type of files: application/zip
- responseType in axios

## How to check the new features
Select several invoices and click on download files icon


