### PR TITLE
Fix chart start 01 instead 00 hour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Unreleased
+- Fix displaced 1 hour in curves chart
+
 ## 1.2.1 (2025-01-13)
 - Avoid errors when a new maturity is added
 - Upgrade somenergia-ui to 0.5.1 that fixes curve labels

--- a/frontend/src/services/curves.js
+++ b/frontend/src/services/curves.js
@@ -39,10 +39,11 @@ function array2datapoints(first_timestamp, values, step_ms = 60 * 60 * 1000) {
 
 function timeInterval(scope, current_date) {
   const start = new Date(current_date)
-  start.setHours(0)
+  start.setHours(1)
   start.setMinutes(0)
   start.setSeconds(0)
   start.setMilliseconds(0)
+
   if (scope === 'MONTHLY') {
     start.setDate(1)
   }

--- a/frontend/src/services/curves.test.js
+++ b/frontend/src/services/curves.test.js
@@ -84,63 +84,63 @@ describe('index2time', () => {
 
 describe('timeInterval', () => {
   it('Day time interval, current start of day', () => {
-    expect(timeInterval('DAILY', new Date('2020-03-02T00:00:00'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-03T00:00:00'),
+    expect(timeInterval('DAILY', new Date('2020-03-02T01:00:00'))).toStrictEqual([
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-03T01:00:00'),
     ])
   })
   it('Day time interval, within day', () => {
     expect(timeInterval('DAILY', new Date('2020-03-02T09:00:00'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-03T00:00:00'),
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-03T01:00:00'),
     ])
   })
   it('Day time interval, within day in UTC offset affects', () => {
     expect(timeInterval('DAILY', new Date('2020-03-01T23:10:00Z'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-03T00:00:00'),
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-03T01:00:00'),
     ])
   })
   it('Day time interval, within day in UTC offset does not affect', () => {
     expect(timeInterval('DAILY', new Date('2020-03-02T22:10:00Z'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-03T00:00:00'),
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-03T01:00:00'),
     ])
   })
   it('Month time interval, within month', () => {
     expect(timeInterval('MONTHLY', new Date('2020-03-02T22:10:00Z'))).toStrictEqual([
-      new Date('2020-03-01T00:00:00'),
-      new Date('2020-04-01T00:00:00'),
+      new Date('2020-03-01T01:00:00'),
+      new Date('2020-04-01T01:00:00'),
     ])
   })
   it('Year time interval, within year', () => {
     expect(timeInterval('YEARLY', new Date('2020-03-02T22:10:00Z'))).toStrictEqual([
-      new Date('2020-01-01T00:00:00'),
-      new Date('2021-01-01T00:00:00'),
+      new Date('2020-01-01T01:00:00'),
+      new Date('2021-01-01T01:00:00'),
     ])
   })
   it('Week time interval, monday', () => {
     expect(timeInterval('WEEKLY', new Date('2020-03-02T22:10:00Z'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-09T00:00:00'),
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-09T01:00:00'),
     ])
   })
   it('Week time interval, tuesday', () => {
     expect(timeInterval('WEEKLY', new Date('2020-03-03T22:10:00Z'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-09T00:00:00'),
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-09T01:00:00'),
     ])
   })
   it('Week time interval, sunday', () => {
     expect(timeInterval('WEEKLY', new Date('2020-03-08T22:10:00Z'))).toStrictEqual([
-      new Date('2020-03-02T00:00:00'),
-      new Date('2020-03-09T00:00:00'),
+      new Date('2020-03-02T01:00:00'),
+      new Date('2020-03-09T01:00:00'),
     ])
   })
   it('Week time interval, sunday, crossing months', () => {
     expect(timeInterval('WEEKLY', new Date('2020-03-01T22:10:00Z'))).toStrictEqual([
-      new Date('2020-02-24T00:00:00'),
-      new Date('2020-03-02T00:00:00'),
+      new Date('2020-02-24T01:00:00'),
+      new Date('2020-03-02T01:00:00'),
     ])
   })
 })

--- a/frontend/src/services/ovapi.js
+++ b/frontend/src/services/ovapi.js
@@ -333,8 +333,16 @@ function invoicesZip(invoiceNumbers) {
     })
 }
 
+export function setTimeInterval(first_timestamp_utc, last_timestamp_utc) {
+  let hourToAdd = 60 *60 *1000
+  first_timestamp_utc.setTime(first_timestamp_utc.getTime() + hourToAdd)
+  last_timestamp_utc.setDate(last_timestamp_utc.getDate() + 1)
+  last_timestamp_utc.setTime(last_timestamp_utc.getTime() + hourToAdd)
+}
+
 async function productionData(first_timestamp_utc, last_timestamp_utc, contract_number) {
   const context = i18n.t('OVAPI.CONTEXT_PRODUCTION_DATA')
+  setTimeInterval(first_timestamp_utc, last_timestamp_utc)
   return axios
     .get('/api/production_data', {
       params: {


### PR DESCRIPTION
## Description

Curve chart label is displaced 1 hour

## Changes

Fix start hour to 1 instead 0.

## Checklist

Justify any unchecked point:

- [X] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation
