### PR TITLE
🐛 fix globeager

### DIFF
--- a/frontend/src/components/AuthProvider.jsx
+++ b/frontend/src/components/AuthProvider.jsx
@@ -3,7 +3,7 @@ const configuredBackend = import.meta.env.VITE_AUTH_BACKEND ?? "Oauth2"
 // TODO: This would be a better approach but does not work in build just in dev
 //const { AuthProvider, useAuth } = import(`./AuthProvider${configuredBackend}.jsx`)
 
-const backends = import.meta.globEager("./AuthProvider?*.jsx")
+const backends = import.meta.glob("./AuthProvider?*.jsx", { eager: true })
 const selectableBackends = Object.fromEntries(
   Object.keys(backends).map((key) => {
     const code = key.slice("./AuthProvider".length, -".jsx".length)

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -396,7 +395,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -418,7 +416,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -481,7 +478,6 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -519,7 +515,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1219,7 +1214,6 @@
     "node_modules/@mui/icons-material": {
       "version": "6.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0"
       },
@@ -1244,7 +1238,6 @@
     "node_modules/@mui/material": {
       "version": "6.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -1371,7 +1364,6 @@
     "node_modules/@mui/system": {
       "version": "6.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/private-theming": "^6.4.9",
@@ -1450,7 +1442,6 @@
     "node_modules/@mui/x-date-pickers": {
       "version": "7.29.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
@@ -2154,7 +2145,6 @@
       "version": "8.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2391,7 +2381,6 @@
     "node_modules/@types/react": {
       "version": "18.3.28",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2577,7 +2566,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2938,7 +2926,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3406,8 +3393,7 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.20",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3788,7 +3774,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4612,7 +4597,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -4620,7 +4604,6 @@
     "node_modules/i18next-browser-languagedetector": {
       "version": "7.2.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -5089,7 +5072,6 @@
       "version": "24.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5320,6 +5302,7 @@
     "node_modules/jwt-decode": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6010,7 +5993,6 @@
     "node_modules/prettier": {
       "version": "3.8.3",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6120,7 +6102,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6131,7 +6112,6 @@
     "node_modules/react-confetti-explosion": {
       "version": "2.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21",
         "react-jss": "^10.9.2"
@@ -6164,7 +6144,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6176,7 +6155,6 @@
     "node_modules/react-i18next": {
       "version": "14.1.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "html-parse-stringify": "^3.0.1"
@@ -6319,7 +6297,6 @@
     "node_modules/recharts": {
       "version": "2.15.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
@@ -6431,7 +6408,6 @@
       "version": "4.60.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6884,7 +6860,6 @@
     "node_modules/styled-components": {
       "version": "6.4.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -7187,12 +7162,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/universal-cookie": {
       "version": "6.1.3",
       "license": "MIT",
@@ -7279,7 +7248,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Description

Error when start: globeager import

<img width="1215" height="158" alt="image" src="https://github.com/user-attachments/assets/21d67df0-fd1c-42e8-b8b9-8c9e47fc2c2a" />

`import.meta.globEager()` va ser deprecated a `Vite 2.8` i eliminat a Vite 3. Era l'API original, però la van substituir per l'opció `{ eager: true }` dins de `import.meta.glob()` per unificar tota la funcionalitat en una sola API.

## Changes

- Fix with stadard code
